### PR TITLE
Enh/5/unit test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ on:
       - feature/*
       - enh/1/testing-python-code
       - enh/3/refactor-code
+      - enh/5/unit-test
   pull_request:
     branches:
       - main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "joblib",
     "six",
     "mlflow",
+    "pytest-mock",
 ]
 
 [project.scripts]

--- a/tests/test_ingest_data.py
+++ b/tests/test_ingest_data.py
@@ -1,0 +1,50 @@
+import os
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from housepred.ingest_data import fetch_housing_data, load_housing_data
+
+
+@pytest.fixture
+def temp_housing_dir(tmp_path):
+    """Fixture to create a temporary directory for housing data."""
+    temp_dir = tmp_path / "housing"
+    temp_dir.mkdir()
+    return temp_dir
+
+
+@mock.patch("housepred.ingest_data.urllib.request.urlretrieve")
+@mock.patch("housepred.ingest_data.tarfile.open")
+def test_fetch_housing_data(mock_tar_open, mock_urlretrieve, temp_housing_dir):
+    """
+    Test that fetch_housing_data creates the required files and directories
+    without actually downloading files.
+    """
+    housing_url = "https://example.com/housing.tgz"
+    fetch_housing_data(housing_url, str(temp_housing_dir))
+
+    assert os.path.exists(temp_housing_dir)
+
+    mock_urlretrieve.assert_called_once_with(
+        housing_url, os.path.join(temp_housing_dir, "housing.tgz")
+    )
+
+    mock_tar_open.assert_called_once_with(os.path.join(temp_housing_dir, "housing.tgz"))
+
+
+def test_load_housing_data(temp_housing_dir):
+    """
+    Test that load_housing_data correctly loads a CSV file into a DataFrame.
+    """
+
+    csv_path = os.path.join(temp_housing_dir, "housing.csv")
+    sample_data = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    sample_data.to_csv(csv_path, index=False)
+
+    df = load_housing_data(str(temp_housing_dir))
+
+    assert df.shape == (2, 2)
+    assert list(df.columns) == ["col1", "col2"]
+    assert df.iloc[0]["col1"] == 1

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,138 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.ensemble import RandomForestRegressor
+
+from housepred.score import preprocess_features, score_model
+
+sys.path.append(".")
+
+
+@pytest.fixture
+def sample_data():
+    """Create a sample housing dataset for testing."""
+    n_samples = 100
+
+    np.random.seed(42)
+    data = {
+        "median_income": np.random.uniform(0, 10, n_samples),
+        "total_rooms": np.random.randint(1, 20, n_samples),
+        "total_bedrooms": np.random.randint(1, 10, n_samples),
+        "households": np.random.randint(1, 5, n_samples),
+        "population": np.random.randint(1, 10, n_samples),
+        "median_house_value": np.random.randint(100000, 500000, n_samples),
+        "ocean_proximity": np.random.choice(
+            ["<1H OCEAN", "INLAND", "NEAR OCEAN", "NEAR BAY", "ISLAND"],
+            n_samples,
+        ),
+    }
+
+    data["median_income"][0:5] = [1.0, 2.0, 3.5, 5.0, 7.0]
+
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def trained_model():
+    """Create a trained model that matches the feature set in score_model."""
+    features = [
+        "median_income",
+        "total_rooms",
+        "total_bedrooms",
+        "households",
+        "population",
+        "rooms_per_household",
+        "bedrooms_per_room",
+        "population_per_household",
+        "ocean_proximity_NEAR BAY",
+        "ocean_proximity_NEAR OCEAN",
+    ]
+    model = RandomForestRegressor(n_estimators=2, max_depth=2, random_state=42)
+
+    X = np.random.rand(20, len(features))
+    y = np.random.rand(20)
+
+    model.fit(X, y)
+    return model
+
+
+def test_preprocess_features():
+    """Test the preprocess_features function."""
+
+    test_data = pd.DataFrame(
+        {
+            "total_rooms": [10, 20, 30],
+            "households": [2, 4, 6],
+            "total_bedrooms": [4, 8, 12],
+            "population": [6, 12, 18],
+        }
+    )
+
+    processed_data = preprocess_features(test_data)
+
+    assert "rooms_per_household" in processed_data.columns
+    assert "bedrooms_per_room" in processed_data.columns
+    assert "population_per_household" in processed_data.columns
+
+    assert processed_data["rooms_per_household"].iloc[0] == 5.0
+    assert processed_data["bedrooms_per_room"].iloc[0] == 0.4
+    assert processed_data["population_per_household"].iloc[0] == 3.0
+
+
+@patch("mlflow.log_metric")
+@patch("mlflow.log_artifact")
+def test_score_model(
+    mock_log_artifact, mock_log_metric, sample_data, trained_model, tmp_path
+):
+    """Test the score_model function with mocked dependencies."""
+
+    data_path = os.path.join(tmp_path, "housing.csv")
+    model_path = os.path.join(tmp_path, "model.joblib")
+    output_path = os.path.join(tmp_path, "results.txt")
+
+    sample_data.to_csv(data_path, index=False)
+    joblib.dump(trained_model, model_path)
+
+    with patch("joblib.load", return_value=trained_model):
+
+        with patch.object(
+            trained_model, "predict", return_value=np.array([200000] * 20)
+        ):
+            score_model(model_path, data_path, output_path)
+
+    assert os.path.exists(output_path)
+
+    mock_log_metric.assert_called()
+    mock_log_artifact.assert_called_with(output_path)
+
+    with open(output_path, "r") as f:
+        content = f.read()
+        assert "Root Mean Squared Error:" in content
+
+
+def test_cli_arguments():
+    """Test the CLI argument parsing."""
+    with patch("argparse.ArgumentParser.parse_args") as mock_args:
+
+        mock_args.return_value = MagicMock(
+            model_path="model.joblib",
+            data_path="data.csv",
+            output_path="results.txt",
+            log_level="INFO",
+            log_path=None,
+            no_console_log=False,
+        )
+
+        with patch("housepred.score.score_model") as mock_score:
+            from housepred.score import cli
+
+            cli()
+
+            mock_score.assert_called_once_with(
+                "model.joblib", "data.csv", "results.txt"
+            )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+
+import joblib
+import mlflow
+import pandas as pd
+import pytest
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import LinearRegression
+from sklearn.tree import DecisionTreeRegressor
+
+from housepred.train import train_model
+
+
+def create_dummy_data(file_path):
+    data = {
+        "longitude": [-122.23, -122.25, -122.26],
+        "latitude": [37.88, 37.86, 37.85],
+        "housing_median_age": [41, 21, 52],
+        "total_rooms": [880, 7099, 1467],
+        "total_bedrooms": [129, 1106, 190],
+        "population": [322, 2401, 496],
+        "households": [126, 1138, 177],
+        "median_income": [8.3252, 8.3014, 7.2574],
+        "median_house_value": [452600, 358500, 352100],
+        "ocean_proximity": ["NEAR BAY", "INLAND", "NEAR OCEAN"],
+    }
+    df = pd.DataFrame(data)
+    df.to_csv(file_path, index=False)
+
+
+@pytest.mark.parametrize("model_type", ["linear", "tree", "forest"])
+def test_train_model(model_type):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = os.path.join(tmpdir, "dummy_data.csv")
+        output_path = os.path.join(tmpdir, "model.pkl")
+
+        create_dummy_data(input_path)
+
+        with mlflow.start_run():
+            train_model(input_path, output_path, model_type)
+
+        assert os.path.exists(
+            output_path
+        ), f"Model file was not created for {model_type}"
+        model = joblib.load(output_path)
+        assert model is not None, "Loaded model is None"
+
+        if model_type == "linear":
+            assert isinstance(model, LinearRegression)
+        elif model_type == "tree":
+            assert isinstance(model, DecisionTreeRegressor)
+        elif model_type == "forest":
+            assert isinstance(model, RandomForestRegressor)


### PR DESCRIPTION

closes #5 

## Description  
This PR adds unit tests for various modules, sets up a GitHub Actions workflow for package building and testing, and ensures that test failures are addressed before proceeding with the build. The workflow includes environment setup, installation steps, and validation of the directory structure post-build.  

## Tasks Completed  

### Unit Testing  
- Implemented unit tests for key logic in different modules.  
- Verified that tests run successfully before the build process.  
- Ensured proper test coverage for `ingest_data.py`, `train.py`, and `score.py`.  

### GitHub Workflow Setup  
- Configured a workflow job for package building, including:  
  - Setting up a Conda environment.  
  - Installing required dependencies, including `tree`.  
  - Displaying the directory structure after the build process.  
  - Installing the package in development mode.  
  - Running `pytest` to execute unit tests.  
  - Ensuring the workflow fails if any test fails.  

### Test Execution & Results  
- The latest workflow run successfully executed all tests: [[Workflow Run Link](https://github.com/RitamSharmaTA/mle-training-2/actions/runs/13541303473)](https://github.com/RitamSharmaTA/mle-training-2/actions/runs/13541303473).  
- **Pytest Results:**  

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.4, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/runner/work/mle-training-2/mle-training-2
configfile: pyproject.toml
plugins: mock-3.14.0
collecting ... collected 11 items

tests/test_custom_install.py::test_package_import PASSED                 
tests/test_custom_install.py::test_cli_commands[cmd0] PASSED             
tests/test_dependencies_install.py::test_installation PASSED             
tests/test_ingest_data.py::test_fetch_housing_data PASSED                
tests/test_ingest_data.py::test_load_housing_data PASSED                 
tests/test_score.py::test_preprocess_features PASSED                     
tests/test_score.py::test_score_model PASSED                             
tests/test_score.py::test_cli_arguments PASSED                           
tests/test_train.py::test_train_model[linear] PASSED                     
tests/test_train.py::test_train_model[tree] PASSED                       
tests/test_train.py::test_train_model[forest] PASSED                     

=============================== warnings summary ===============================
../../../.local/lib/python3.12/site-packages/pydantic/_internal/_config.py:295
  /home/runner/.local/lib/python3.12/site-packages/pydantic/_internal/_config.py:295: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 11 passed, 1 warning in 5.34s =========================
```

## Deliverables  
- [x] Successful GitHub Actions workflow run for test jobs.  
- [x] Workflow validation of the package build process.  
- [x] Verified pytest execution before package build.  
